### PR TITLE
enable dismiss button for sticky notifications

### DIFF
--- a/notify-osd.js
+++ b/notify-osd.js
@@ -78,7 +78,7 @@
         },
 
         set_dismissable : function (dismissable) {
-          if (opts.dismissable) {
+          if (opts.dismissable || opts.sticky) {
             $(this).children('div').append_or_replace('<a href="#" class="notify-osd-dismiss" title="Dismiss">x</a>','.notify-osd-dismiss');
             $('.notify-osd-dismiss').unbind('click').click(function () {
               notif_obj.dismiss();


### PR DESCRIPTION
Only other way to remove a sticky notification is to produce another
notification: not ideal if the user doesn't want the popup to lurk around for
long.

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com
